### PR TITLE
Fixed infinite loop due to letter 'Z'

### DIFF
--- a/indic_transliteration/font_converter/krutidev2unicode.py
+++ b/indic_transliteration/font_converter/krutidev2unicode.py
@@ -535,7 +535,7 @@ def kru2uni(kru_text):
     while misplaced:
         misplaced = misplaced.group(1)
         index_r_halant = kru_text.index(misplaced + 'Z')
-        while index_r_halant >= 0 and kru_text[index_r_halant] in unicode_vowel_signs:
+        while index_r_halant > 0 and kru_text[index_r_halant] in unicode_vowel_signs:
             index_r_halant -= 1
             misplaced = kru_text[index_r_halant] + misplaced
         kru_text = kru_text.replace(misplaced + 'Z', '\u0930\u094d' + misplaced)


### PR DESCRIPTION
I encountered an issue with an infinite loop while using [krutidev2unicode.py](https://github.com/indic-transliteration/indic_transliteration_py/blob/master/indic_transliteration/font_converter/krutidev2unicode.py) when the string contained the letter `'Z'`.

The problem occurred due to the following reasons:

1. The value of `(misplace + 'Z')` was not found in the `kru_text` string due to addition of last element of string in the start, which caused the replacement process to fail.
2. The loop continued to run until `index_r_halant` became `0`. However, in the next line, this value was decremented again, resulting in `index_r_halant` becoming `-1`. This caused the code to reference the last element of the string.
3. Since the replacement was not happening, the code entered an infinite loop.
I resolved the issue by adjusting the condition in the loop, specifically by removing the `'='` in the condition.